### PR TITLE
Sci notation to decimal form

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,8 @@
 # Changes here will be overwritten by Copier
-_commit: 2.5.0
+_commit: 3.0.0
 _src_path: gh:DiamondLightSource/python-copier-template
-author_email: giles.knap@diamond.ac.uk
-author_name: Giles Knap
+author_email: James.OHea@diamond.ac.uk
+author_name: James OHea
 component_lifecycle: production
 component_owner: group:default/sscc
 component_type: user-interface

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,11 @@
         }
     },
     "features": {
-        // Some default things like git config
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "upgradePackages": false
-        }
+        // add in eternal history and other bash features
+        "ghcr.io/diamondlightsource/devcontainer-features/bash-config:1": {}
     },
+    // Create the config folder for the bash-config feature
+    "initializeCommand": "mkdir -p ${localEnv:HOME}/.config/bash-config",
     "runArgs": [
         // Allow the container to access the host X11 display and EPICS CA
         "--net=host",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,4 +24,4 @@ It is recommended that developers use a [vscode devcontainer](https://code.visua
 
 This project was created using the [Diamond Light Source Copier Template](https://github.com/DiamondLightSource/python-copier-template) for Python projects.
 
-For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/2.5.0/how-to.html).
+For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/3.0.0/how-to.html).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Describe the bug, including a clear and concise description of the expected behavior, the actual behavior and the context in which you encountered it (ideally include details of your environment).
+Describe the bug, including a clear and concise description of the expected behaviour, the actual behavior and the context in which you encountered it (ideally include details of your environment).
 
 ## Steps To Reproduce
 Steps to reproduce the behavior:

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create GitHub Release
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: "*"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -54,7 +54,7 @@ jobs:
         run: tox -e tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           name: ${{ inputs.python-version }}/${{ inputs.runs-on }}
           files: cov.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: ruff
         name: lint with ruff
         language: system
-        entry: ruff check --force-exclude
+        entry: ruff check --force-exclude --fix
         types: [python]
         require_serial: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
-ENTRYPOINT ["dls_backup_bl"]
+ENTRYPOINT ["dls-backup-bl"]
 CMD ["--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
-ENTRYPOINT ["dls-backup-bl"]
+ENTRYPOINT ["dls_backup_bl"]
 CMD ["--version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 description = "A backup tool for beamlines for pmacs, terminal servers, zebras"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 ]
 
 [project.scripts]
-dls-backup-bl2 = "dls_backup_bl.backup:main"
+dls-backup-bl = "dls_backup_bl.backup:main"
 
 [project.urls]
 GitHub = "https://github.com/DiamondLightSource/dls-backup-bl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ name = "dls-backup-bl"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 description = "A backup tool for beamlines for pmacs, terminal servers, zebras"
 dependencies = [
@@ -27,7 +27,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.setuptools.package-data]
 gitConfig = ["src/dls_backup_bl/global_git_config/.gitconfig"]
@@ -53,8 +53,8 @@ dls-backup-bl2 = "dls_backup_bl.backup:main"
 GitHub = "https://github.com/DiamondLightSource/dls-backup-bl"
 
 [[project.authors]] # Further authors may be added by duplicating this section
-email = "giles.knap@diamond.ac.uk"
-name = "Giles Knap"
+email = "James.OHea@diamond.ac.uk"
+name = "James OHea"
 
 
 [tool.setuptools_scm]

--- a/src/dls_backup_bl/backup.py
+++ b/src/dls_backup_bl/backup.py
@@ -154,7 +154,7 @@ class BackupBeamline:
             "--dir",
             action="store",
             help="Directory to save backups to. Defaults to"
-            "/dls_sw/motion/Backups/BLXXY",
+            "/dls_sw/work/motion/Backups/BLXXY",
         )
         parser.add_argument(
             "-j",
@@ -310,7 +310,7 @@ class BackupBeamline:
     def check_restore(self):
         print(
             "\nAre you sure? This will restore the most recent commit "
-            "and\noverwrite the motor positions on all pmacs (Y/N)"
+            "and\noverwrite the motor positions on all specified pmacs (Y/N)"
         )
         reply = input()
         if reply[0].lower() != "y":

--- a/src/dls_backup_bl/backup.py
+++ b/src/dls_backup_bl/backup.py
@@ -162,7 +162,7 @@ class BackupBeamline:
             action="store",
             type=int,
             default=4,
-            help="Number of times to attempt backup. " "Defaults to 4",
+            help="Number of times to attempt backup. Defaults to 4",
         )
         parser.add_argument(
             "-t",
@@ -206,7 +206,7 @@ class BackupBeamline:
         parser.add_argument(
             "--folder",
             action="store_true",
-            help="report the motion backup folder that the " "tool will use.",
+            help="report the motion backup folder that the tool will use.",
         )
 
         # Parse the command line arguments
@@ -336,7 +336,7 @@ class BackupBeamline:
         # finish up
         self.sort_log()
         if total == 0:
-            log.critical("Nothing was backed up " "(incorrect --devices argument?)")
+            log.critical("Nothing was backed up (incorrect --devices argument?)")
 
         if not self.args.positions:
             commit_changes(self.defaults, do_positions=False)
@@ -352,8 +352,7 @@ class BackupBeamline:
         if self.args.positions:
             print("The following command reviews the position files")
             print(
-                f"more {self.defaults.motion_folder}/*"
-                f"{self.defaults.positions_suffix}"
+                f"more {self.defaults.motion_folder}/*{self.defaults.positions_suffix}"
             )
 
     def cancel(self, sig, frame):

--- a/src/dls_backup_bl/brick.py
+++ b/src/dls_backup_bl/brick.py
@@ -158,12 +158,16 @@ class Brick:
                             # Determine axis number M variable is related to
                             if newL[0] == "M" or "m":
                                 axisNo = int(int(newL[0][1:]) / 100)
-                                scaling_factor = f"{1/positionSFList[axisNo]}"
+                                scaling_factor = f"{1 / positionSFList[axisNo]}"
                                 # The controller can't parse values in scientific notation (eg 3.69e-05)
                                 # These need replacing with their decimal form equivalent
                                 if "e-" in scaling_factor:
-                                   parts = scaling_factor.split("e-")
-                                   scaling_factor = "0." + ('0' * (int(parts[1])-1)) + parts[0].replace('.', "")
+                                    parts = scaling_factor.split("e-")
+                                    scaling_factor = (
+                                        "0."
+                                        + ("0" * (int(parts[1]) - 1))
+                                        + parts[0].replace(".", "")
+                                    )
                                 newL[1] = int(newL[1]) * (1 / positionSFList[axisNo])
                                 newL[1] = f"{int(newL[1])}/{scaling_factor}"
                                 lines[i] = f"{newL[0]} = {newL[1]}\n"
@@ -195,8 +199,7 @@ class Brick:
             break
         else:
             msg = (
-                f"ERROR: {self.desc} all {self.defaults.retries} "
-                f"backup attempts failed"
+                f"ERROR: {self.desc} all {self.defaults.retries} backup attempts failed"
             )
             log.critical(msg)
 
@@ -236,8 +239,7 @@ class Brick:
             break
         else:
             msg = (
-                f"ERROR: {self.desc} all {self.defaults.retries} "
-                f"backup attempts failed"
+                f"ERROR: {self.desc} all {self.defaults.retries} backup attempts failed"
             )
             log.critical(msg)
 
@@ -254,9 +256,7 @@ class Brick:
             with pmc_file.open("r") as f:
                 pmc = f.read()
         except (FileNotFoundError, LookupError):
-            log.error(
-                f"could not read i08 for {brick} " f"assuming i08 == 32 for all axes"
-            )
+            log.error(f"could not read i08 for {brick} assuming i08 == 32 for all axes")
             pmc = ""
 
         for axis in range(1, 33):

--- a/src/dls_backup_bl/brick.py
+++ b/src/dls_backup_bl/brick.py
@@ -150,7 +150,7 @@ class Brick:
 
                     # Mx62 in some cases cannot be written directly to the controller as the maximum
                     # acceptable value appears to be 2^35. Here the value of Mx62 is calculated as a factor
-                    # of 1/(ix08*23) is written to the pmac as an expression
+                    # of 1/(ix08*32) is written to the pmac as an expression
                     for i, line in enumerate(lines):
                         newL = line.split("=")
                         newL = [a.strip() for a in newL]
@@ -158,8 +158,14 @@ class Brick:
                             # Determine axis number M variable is related to
                             if newL[0] == "M" or "m":
                                 axisNo = int(int(newL[0][1:]) / 100)
+                                scaling_factor = f"{1/positionSFList[axisNo]}"
+                                # The controller can't parse values in scientific notation (eg 3.69e-05)
+                                # These need replacing with their decimal form equivalent
+                                if "e-" in scaling_factor:
+                                   parts = scaling_factor.split("e-")
+                                   scaling_factor = "0." + ('0' * (int(parts[1])-1)) + parts[0].replace('.', "")
                                 newL[1] = int(newL[1]) * (1 / positionSFList[axisNo])
-                                newL[1] = f"{int(newL[1])}/{1/positionSFList[axisNo]}"
+                                newL[1] = f"{int(newL[1])}/{scaling_factor}"
                                 lines[i] = f"{newL[0]} = {newL[1]}\n"
 
                     pmc = [

--- a/src/dls_backup_bl/brick.py
+++ b/src/dls_backup_bl/brick.py
@@ -2,6 +2,7 @@ import math
 import re
 import shutil
 import telnetlib
+from decimal import Decimal
 from logging import getLogger
 
 from dls_pmacanalyse.errors import PmacReadError
@@ -148,9 +149,9 @@ class Brick:
                     # that match restore_commands
                     lines = f.readlines()
 
-                    # Mx62 in some cases cannot be written directly to the controller as the maximum
-                    # acceptable value appears to be 2^35. Here the value of Mx62 is calculated as a factor
-                    # of 1/(ix08*32) is written to the pmac as an expression
+                    # In some cases Mx62 cannot be written directly to the controller as the maximum
+                    # acceptable value appears to be 2^35. Instead the value of Mx62 is calculated as
+                    # a factor of 1/(ix08*32) and written to the pmac as an expression
                     for i, line in enumerate(lines):
                         newL = line.split("=")
                         newL = [a.strip() for a in newL]
@@ -161,13 +162,7 @@ class Brick:
                                 scaling_factor = f"{1 / positionSFList[axisNo]}"
                                 # The controller can't parse values in scientific notation (eg 3.69e-05)
                                 # These need replacing with their decimal form equivalent
-                                if "e-" in scaling_factor:
-                                    parts = scaling_factor.split("e-")
-                                    scaling_factor = (
-                                        "0."
-                                        + ("0" * (int(parts[1]) - 1))
-                                        + parts[0].replace(".", "")
-                                    )
+                                scaling_factor = Decimal(scaling_factor)
                                 newL[1] = int(newL[1]) * (1 / positionSFList[axisNo])
                                 newL[1] = f"{int(newL[1])}/{scaling_factor}"
                                 lines[i] = f"{newL[0]} = {newL[1]}\n"

--- a/src/dls_backup_bl/repository.py
+++ b/src/dls_backup_bl/repository.py
@@ -54,7 +54,7 @@ def compare_changes(defaults: Defaults, pmacs):
                 file_out += f"\n{name}\n{patch}"
 
         if len(diff) == 0:
-            output += "\nThere are no changes to positions since the last " "commit"
+            output += "\nThere are no changes to positions since the last commit"
         filepath = defaults.motion_folder / defaults.positions_file
         with filepath.open("w") as f:
             f.write(f"{output}\n{file_out}")

--- a/src/dls_backup_bl/repository.py
+++ b/src/dls_backup_bl/repository.py
@@ -89,7 +89,11 @@ def commit_changes(defaults: Defaults, do_positions=False):
 
         # Gather up any changes
         untracked_files = git_repo.untracked_files
-        modified_files = [diff.a_blob.path for diff in git_repo.index.diff(None)]
+        modified_files = [
+            diff.a_path
+            for diff in git_repo.index.diff(None)
+            if diff.change_type == "M" and diff.a_path is not None
+        ]
 
         ignores = [defaults.log_file.name]
         if not do_positions:


### PR DESCRIPTION
A problem with the restore functionality was identified in BC-1493 - some axes were not being restored correctly

The issue is that when ixx08 is a large number, the mxx62 string written to the controller is in scientific notation form which the controller cannot parse

The fix was to ensure that the string remained in decimal format by using the Decimal class of the decimal module (part of Python's standard library)

I have tested this on the MX spare endstation using the same values which caused an issue in the ticket

I used the update as an opportunity to fix a couple of other things at the same time:

- Giles' fix to make it launch as a module in vscode
- Make modified_files from the Git interactions a list of strings, like untracked_files, check for None, better type handling
- Corrections from ruff formatting
- Correcting a typo, clearer comments and print statement
